### PR TITLE
Fix obsolete links

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@
 Установка нужных пакетов LaTeX в Ubuntu:
 
 ```bash
-sudo apt install texlive-base texlive-latex-extra texlive-xetex texlive-lang-cyrillic latexmk texlive-fonts-extra texlive-math-extra latex-beamer
+sudo apt install texlive-base texlive-latex-extra texlive-xetex texlive-lang-cyrillic latexmk texlive-fonts-extra texlive-science texlive-latex-recommended
 ```
 
 Для сборки проекта понадобится установка шрифтов Times New Roman, XITS Math, PT Sans, PT Mono:
 
 ```bash
 sudo apt install ttf-mscorefonts-installer
-sudo wget -O /usr/share/fonts/xits-math.otf https://github.com/khaledhosny/xits-math/raw/master/xits-math.otf
+sudo wget -O /usr/share/fonts/xits-math.otf https://github.com/khaledhosny/xits-math/raw/master/XITSMath-Regular.otf
 sudo wget https://ftp.tw.freebsd.org/distfiles/xorg/font/{PTSansOFL,PTMonoOFL}.zip
 sudo unzip -o PTSansOFL.zip -d /usr/share/fonts/ && sudo unzip -o PTMonoOFL.zip -d /usr/share/fonts/
 sudo rm -f {PTSansOFL,PTMonoOFL}.zip && sudo fc-cache -f -v


### PR DESCRIPTION
- В Ubuntu 18 пакетов `texlive-math-extra` и `latex-beamer` уже нет. К сожалению не могу проверить, как дела в 16-й и ниже
- Автор шрифта `xits` переименовал файл